### PR TITLE
added ability to configure the package name that is scanned for jobs to run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
+.classpath
+.project
 dropwizard-jobs.iml
 target/

--- a/src/main/java/de/spinscale/dropwizard/jobs/JobManager.java
+++ b/src/main/java/de/spinscale/dropwizard/jobs/JobManager.java
@@ -20,9 +20,17 @@ import java.util.Set;
 public class JobManager implements Managed {
 
     private static final Logger log = LoggerFactory.getLogger(JobManager.class);
-    private Reflections reflections = new Reflections("");
+    private Reflections reflections = null;
     protected Scheduler scheduler;
 
+    public JobManager() {
+    	reflections = new Reflections("");
+    }
+
+    public JobManager(String scanURL) {
+    	reflections = new Reflections(scanURL);
+    }
+    
     @Override
     public void start() throws Exception {
         scheduler = StdSchedulerFactory.getDefaultScheduler();

--- a/src/main/java/de/spinscale/dropwizard/jobs/JobsBundle.java
+++ b/src/main/java/de/spinscale/dropwizard/jobs/JobsBundle.java
@@ -6,13 +6,29 @@ import com.yammer.dropwizard.config.Environment;
 
 public class JobsBundle implements Bundle {
 
+	private String scanURL = null;
+	
     @Override
     public void initialize(Bootstrap<?> bootstrap) {
+    }
+    
+    public JobsBundle() {
+    }
+    
+    public JobsBundle(String scanURL) {
+    	this.scanURL = scanURL;
     }
 
     @Override
     public void run(Environment environment) {
-        environment.manage(new JobManager());
+    	if (scanURL != null)
+    	{
+    		environment.manage(new JobManager(scanURL));
+    	}
+    	else
+    	{
+    		environment.manage(new JobManager());
+    	}
     }
 
 }


### PR DESCRIPTION
Dropwizard-jobs wasn't picking up my jobs when integrating to dw0.6.2, Reflections was complaining on scan() with "given scan urls are empty. set urls in the configuration". This fix allows explicit configuration of the package names when wiring the JobsBundle into the bootstrap 

``` java
    @Override
      public void initialize(Bootstrap<DelaSearchConfiguration> bootstrap) {
      bootstrap.setName("myService");
      bootstrap.addBundle(new JobsBundle("com.package.to.scan"));
    }
```
