### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ public void initialize(Bootstrap<DelaSearchConfiguration> bootstrap) {
 }
 ```
 
+Be aware that Jobs are searched by reflection only in the current package. 
+You can define jobs location by passing package url to the JobsBundle constructor like this:
+
+```java
+  bootstrap.addBundle(new JobsBundle('com.youpackage.url'));
+```
+
 ## Available job types
 
 The <code>@OnApplicationStart</code> annotation triggers a job after the quartz scheduler is started


### PR DESCRIPTION
I struggled for a moment to find out why my Jobs couldn't be found by dropwizard-jobs. Forgive me my wording. I come from .NET world and I don't know if this is exact technically true (that Jobs are searched only in the current package), but the point is you can pass jobs package location as a Bundle argument.
