### PR TITLE
fix: when start do not schedule existing jobs

### DIFF
--- a/dropwizard-jobs-core/src/main/java/io/dropwizard/jobs/JobManager.java
+++ b/dropwizard-jobs-core/src/main/java/io/dropwizard/jobs/JobManager.java
@@ -267,8 +267,10 @@ public class JobManager implements Managed {
         if (!jobDetails.isEmpty()) {
             log.info("Jobs to run on application start:");
             for (JobDetail jobDetail : jobDetails) {
-                scheduler.scheduleJob(jobDetail, executeNowTrigger());
-                log.info("   " + jobDetail.getJobClass().getCanonicalName());
+                if (!scheduler.checkExists(jobDetail.getKey())) {
+                    scheduler.scheduleJob(jobDetail, executeNowTrigger());
+                    log.info("   " + jobDetail.getJobClass().getCanonicalName());
+                }
             }
         }
     }


### PR DESCRIPTION
Basically trying to avoid issue https://github.com/dropwizard-jobs/dropwizard-jobs/issues/131 that happens every time it restarts the application using `JobStoreTX` since it will try to schedule an existing job key,