### PR TITLE
Replace jobs that already exist (OnApplicationStart)

### DIFF
--- a/dropwizard-jobs-core/src/main/java/io/dropwizard/jobs/JobManager.java
+++ b/dropwizard-jobs-core/src/main/java/io/dropwizard/jobs/JobManager.java
@@ -3,6 +3,7 @@ package io.dropwizard.jobs;
 import io.dropwizard.jobs.annotations.*;
 import io.dropwizard.jobs.parser.TimeParserUtil;
 import io.dropwizard.lifecycle.Managed;
+import io.dropwizard.util.Sets;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.WordUtils;
 import org.joda.time.DateTime;
@@ -267,7 +268,7 @@ public class JobManager implements Managed {
         if (!jobDetails.isEmpty()) {
             log.info("Jobs to run on application start:");
             for (JobDetail jobDetail : jobDetails) {
-                scheduler.scheduleJob(jobDetail, executeNowTrigger());
+                scheduler.scheduleJob(jobDetail, Sets.of(executeNowTrigger()), true);
                 log.info("   " + jobDetail.getJobClass().getCanonicalName());
             }
         }


### PR DESCRIPTION
We are having an intermittent issue when using jobs that are scheduled @OnApplicationStart.

If the job was already scheduled for some reason, it bubbles an exception and the application doesn't start:

```
org.quartz.ObjectAlreadyExistsException: Unable to store Job : 'DEFAULT.{package}.{class}Job', because one already exists with this identification.
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.storeJob(JobStoreSupport.java:1113)
	at org.quartz.impl.jdbcjobstore.JobStoreSupport$2.executeVoid(JobStoreSupport.java:1067)
	at org.quartz.impl.jdbcjobstore.JobStoreSupport$VoidTransactionCallback.execute(JobStoreSupport.java:3780)
	at org.quartz.impl.jdbcjobstore.JobStoreSupport$VoidTransactionCallback.execute(JobStoreSupport.java:3778)
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.executeInNonManagedTXLock(JobStoreSupport.java:3864)
	at org.quartz.impl.jdbcjobstore.JobStoreTX.executeInLock(JobStoreTX.java:93)
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.storeJobAndTrigger(JobStoreSupport.java:1063)
	at org.quartz.core.QuartzScheduler.scheduleJob(QuartzScheduler.java:855)
	at org.quartz.impl.StdScheduler.scheduleJob(StdScheduler.java:249)
	at io.dropwizard.jobs.JobManager.scheduleAllJobsOnApplicationStart(JobManager.java:270)
	at io.dropwizard.jobs.JobManager.scheduleAllJobs(JobManager.java:72)
	at io.dropwizard.jobs.JobManager.start(JobManager.java:48)
	at io.dropwizard.lifecycle.JettyManaged.doStart(JettyManaged.java:27)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:72)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:169)
	at org.eclipse.jetty.server.Server.start(Server.java:407)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:117)
	at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:100)
	at org.eclipse.jetty.server.Server.doStart(Server.java:371)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:72)
	at io.dropwizard.cli.ServerCommand.run(ServerCommand.java:53)
	at io.dropwizard.cli.EnvironmentCommand.run(EnvironmentCommand.java:45)
	at io.dropwizard.cli.ConfiguredCommand.run(ConfiguredCommand.java:87)
	at io.dropwizard.cli.Cli.run(Cli.java:79)
	at io.dropwizard.Application.run(Application.java:94)
```

Passing the parameter to "replace" the job if it already exists will get rid of the issue.

Closes #131.
