### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <maven-javadoc-plugin.version>3.2.1</maven-javadoc-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+    	<closeTestReports>true</closeTestReports>
     </properties>
 
     <developers>
@@ -204,6 +205,11 @@
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${maven-surefire-plugin.version}</version>
+				<configuration>
+					<parallel>classes</parallel>
+					<useUnlimitedThreads>true</useUnlimitedThreads>
+					<disableXmlReport>${closeTestReports}</disableXmlReport>
+				</configuration>
 			</plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>


### PR DESCRIPTION
According to [Maven parallel test](https://www.baeldung.com/maven-junit-parallel-tests), we can run tests in parallel.

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
