### PR TITLE
update maven plugins

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,0 +1,2 @@
+build = "mvn"
+jdkVersion = "11"

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <mockito.version>3.2.4</mockito.version>
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-        <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.2.1</maven-javadoc-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,31 +14,31 @@
     <!-- To check for outdated dependencies, run: mvn versions:display-dependency-updates -->
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dropwizard.version>3.0.0</dropwizard.version>
-        <spring.version>5.3.27</spring.version>
-        <guice.version>4.2.2</guice.version>
-        <quartz.version>2.3.2</quartz.version>
+    	<closeTestReports>true</closeTestReports>
+        <assertj.version>3.24.2</assertj.version>
         <c3p0.version>0.9.5.5</c3p0.version>
+        <commons-text.version>1.10.0</commons-text.version>
+        <dropwizard.version>3.0.0</dropwizard.version>
+        <guice.version>4.2.2</guice.version>
+        <hamcrest.version>2.2</hamcrest.version>
         <jackson.version>2.15.1</jackson.version>
+        <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
         <javax.activation.version>1.1.1</javax.activation.version>
         <jaxb-api.version>2.4.0-b180830.0359</jaxb-api.version>
         <jaxb-runtime.version>2.4.0-b180830.0438</jaxb-runtime.version>
-        <junit.version>4.13.1</junit.version>
-        <junit.jupiter.version>5.7.0</junit.jupiter.version>
-        <assertj.version>3.24.2</assertj.version>
-        <hamcrest.version>2.2</hamcrest.version>
-        <mockito.version>3.2.4</mockito.version>
-        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-        <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
-        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-        <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
-        <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
-        <maven-surefire-plugin.version>3.1.0</maven-surefire-plugin.version>
-        <commons-text.version>1.10.0</commons-text.version>
-        <snakeyaml.version>2.0</snakeyaml.version>
         <jetty.version>9.4.51.v20230217</jetty.version>
-    	<closeTestReports>true</closeTestReports>
+        <junit.jupiter.version>5.7.0</junit.jupiter.version>
+        <junit.version>4.13.1</junit.version>
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
+        <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+        <maven-surefire-plugin.version>3.1.0</maven-surefire-plugin.version>
+        <mockito.version>3.2.4</mockito.version>
+        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+        <quartz.version>2.3.2</quartz.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
+        <spring.version>5.3.27</spring.version>
     </properties>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
-        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+        <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <commons-text.version>1.10.0</commons-text.version>
         <snakeyaml.version>2.0</snakeyaml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
         <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.1.0</maven-surefire-plugin.version>
         <commons-text.version>1.10.0</commons-text.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <jetty.version>9.4.51.v20230217</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <assertj.version>3.24.2</assertj.version>
         <hamcrest.version>2.2</hamcrest.version>
         <mockito.version>3.2.4</mockito.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
         <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
@@ -263,8 +263,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin.version}</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <source>11</source>
+                        <target>11</target>
                     </configuration>
                 </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-        <maven-javadoc-plugin.version>3.2.1</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <commons-text.version>1.10.0</commons-text.version>


### PR DESCRIPTION
- update maven-compiler-plugin to v3.11.0
- [update jacoco-maven-plugin to v0.8.10](https://github.com/dropwizard-jobs/dropwizard-jobs/pull/161/commits/6891849e07bad38542c243a3aa08f6b5fa0a5a40)
- [update maven-javadoc-plugin to v3.5.0](https://github.com/dropwizard-jobs/dropwizard-jobs/pull/161/commits/a0a838defcd93480e6c1a16a532f81b39bc04b50)
- [update maven-gpg-plugin to v3.1.0](https://github.com/dropwizard-jobs/dropwizard-jobs/pull/161/commits/3f5f5340c83342aed754920b42f06afda27c53a0)
- [update maven-surefire-plugin to v3.1.0](https://github.com/dropwizard-jobs/dropwizard-jobs/pull/161/commits/f788a446ee1253c45171bb919c5ae7747fb8a149)