### PR TITLE
Update README.md @On timezone example

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The <code>@On</code> annotation allows one to use cron-like expressions for comp
 This expression would run on Mondays at 1pm, Los Angeles time. If the optional parameter `timeZone` is not set system default will be used. 
 
 ```java
-@On("0 0 13 ? * MON", timeZone = "America/Los_Angeles")
+@On(value = "0 0 13 ? * MON", timeZone = "America/Los_Angeles")
 public class OnTestJob extends Job {
   @Override
   public void doJob(JobExecutionContext context) throws JobExecutionException {


### PR DESCRIPTION
Without `value =` an error is thrown
`Syntax error on token ""0 0 13 ? * MON"", invalid MemberValuePairsJava(1610612971)`

Looking at #66 it seems that  adding `value =` is needed which indeed removes the error

cc #69