### PR TITLE
Fix for Missing Override annotation

### DIFF
--- a/dropwizard-jobs-core/src/test/java/io/dropwizard/jobs/JobManagerTest.java
+++ b/dropwizard-jobs-core/src/test/java/io/dropwizard/jobs/JobManagerTest.java
@@ -415,6 +415,7 @@ public class JobManagerTest {
 
         private final Map<String, String> jobs = new HashMap<>();
 
+        @Override
         public Map<String, String> getJobs() {
             return jobs;
         }


### PR DESCRIPTION
Add `@Override` directly above `getJobs()` in `TestConfig` within `dropwizard-jobs-core/src/test/java/io/dropwizard/jobs/JobManagerTest.java`.

- General fix: annotate all methods that override superclass/interface methods with `@Override`.
- Best minimal fix here: only change the flagged method (`getJobs`) to include `@Override`, without changing logic or behavior.
- File/region: `JobManagerTest.java`, inside `private static class TestConfig extends JobConfiguration`, around lines 418–420.
- No imports, dependencies, or method signature changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._