### PR TITLE
Fix for Unread local variable

### DIFF
--- a/dropwizard-jobs-hk2/src/main/java/io/dropwizard/jobs/Hk2JobFactory.java
+++ b/dropwizard-jobs-hk2/src/main/java/io/dropwizard/jobs/Hk2JobFactory.java
@@ -3,7 +3,6 @@ package io.dropwizard.jobs;
 import org.glassfish.hk2.api.Filter;
 import org.glassfish.hk2.api.ServiceHandle;
 import org.glassfish.hk2.api.ServiceLocator;
-import org.quartz.JobKey;
 import org.quartz.Scheduler;
 import org.quartz.spi.JobFactory;
 import org.quartz.spi.TriggerFiredBundle;
@@ -33,7 +32,6 @@ public class Hk2JobFactory implements JobFactory {
 
     @Override
     public org.quartz.Job newJob(TriggerFiredBundle bundle, Scheduler scheduler) {
-        JobKey jobKey = bundle.getJobDetail().getKey();
         Class<? extends org.quartz.Job> jobClass = bundle.getJobDetail().getJobClass();
 
         // Find the service handle for this job class


### PR DESCRIPTION
The best fix is to remove the unused local variable declaration and any now-unused import caused by that removal, without changing behavior.

In `dropwizard-jobs-hk2/src/main/java/io/dropwizard/jobs/Hk2JobFactory.java`:
- Delete line 36 (`JobKey jobKey = bundle.getJobDetail().getKey();`) since it is never read.
- Remove the `import org.quartz.JobKey;` statement (line 6), which becomes unused after deleting the variable.

No new methods, definitions, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._