### PR TITLE
Fix for Missing Override annotation

### DIFF
--- a/dropwizard-jobs-core/src/test/java/io/dropwizard/jobs/JobManagerTest.java
+++ b/dropwizard-jobs-core/src/test/java/io/dropwizard/jobs/JobManagerTest.java
@@ -421,6 +421,7 @@ public class JobManagerTest {
         }
 
         @Override
+        @Override
         public Map<String, String> getQuartzConfiguration() {
             return quartzConfiguration;
         }

--- a/dropwizard-jobs-core/src/test/java/io/dropwizard/jobs/JobManagerTest.java
+++ b/dropwizard-jobs-core/src/test/java/io/dropwizard/jobs/JobManagerTest.java
@@ -420,6 +420,7 @@ public class JobManagerTest {
             return jobs;
         }
 
+        @Override
         public Map<String, String> getQuartzConfiguration() {
             return quartzConfiguration;
         }


### PR DESCRIPTION
Add `@Override` directly above `getQuartzConfiguration` in `TestConfig` within `dropwizard-jobs-core/src/test/java/io/dropwizard/jobs/JobManagerTest.java`.

Best minimal fix (no functional change):
- In the `TestConfig` inner class, annotate `public Map<String, String> getQuartzConfiguration()` with `@Override`.
- No imports are required because `Override` is in `java.lang`.
- No behavior or signatures change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._