### PR TITLE
Fix for Missing Override annotation

### DIFF
--- a/dropwizard-jobs-core/src/main/java/io/dropwizard/jobs/JobManager.java
+++ b/dropwizard-jobs-core/src/main/java/io/dropwizard/jobs/JobManager.java
@@ -335,7 +335,7 @@ public class JobManager implements Managed, JobMediator {
     }
 
     /**
-
+ 
      * Schedules a job to run immediately.
      * <p>
      * This method creates a trigger that fires immediately and schedules the job
@@ -345,6 +345,7 @@ public class JobManager implements Managed, JobMediator {
      * @param jobDetail the job detail describing the job to schedule
      * @throws SchedulerException if the job cannot be scheduled
      */
+    @Override
     public void scheduleNow(JobDetail jobDetail) throws SchedulerException {
         Trigger nowTrigger = nowTrigger();
         scheduler.scheduleJob(jobDetail, Set.of(nowTrigger), true);


### PR DESCRIPTION
Add the `@Override` annotation to the `scheduleNow(JobDetail jobDetail)` method in `dropwizard-jobs-core/src/main/java/io/dropwizard/jobs/JobManager.java`.

Best single fix without changing functionality:
- Edit the method region around line 348.
- Insert `@Override` immediately above `public void scheduleNow(...)`.
- No import changes or dependency changes are required (`@Override` is in `java.lang`).

This preserves behavior while enabling compiler checks that the method continues to match the `JobMediator` contract.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._